### PR TITLE
make find_bin match repr

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -759,10 +759,19 @@ class Map_Classifier(object):
         Returns
         -------
         a bin index or array of bin indices that classify the input into one of
-        the classifiers' bins
+        the classifiers' bins.
+
+        Note that this differs from similar functionality in 
+        numpy.digitize(x, classi.bins, right=True).
+
+        This will always provide the closest bin, so data "outside" the classifier,
+        above and below the max/min breaks, will be classified into the nearest bin.
+
+        numpy.digitize returns k+1 for data greater than the greatest bin, but retains 0
+        for data below the lowest bin. 
         """
         x = np.asarray(x).flatten()
-        uptos = [np.where(value < self.bins)[0] for value in x]
+        uptos = [np.where(value <= self.bins)[0] for value in x]
         #  bail upwards
         bins = [j.min() if j.size > 0 else len(self.bins)-1 for j in uptos]
         bins = np.asarray(bins)

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -90,7 +90,7 @@ class TestMake(unittest.TestCase):
         np.testing.assert_allclose(known, ei_classes)
 
         q5r_classes = [self.q5r(d) for d in self.data]
-        known = [[0,1,2,3,4], [0,1,2,4,4], [0,0,2,4,4]]
+        known = [[0,1,2,3,4], [0,0,2,3,4], [0,0,2,4,4]]
         accreted_data = set(self.q5r.__defaults__[0].y)
         all_data = set(np.asarray(self.data).flatten())
         self.assertEqual(accreted_data, all_data)


### PR DESCRIPTION
This makes the find_bin method closed on the right and open on the left of each of the intervals. 

It addresses [pysal/#968](https://github.com/pysal/pysal/issues/968).

It also adds text to the docstring about how the function is distinct from `np.digitize` in right-mode. 
