### PR TITLE
use digitize over list comprehensions

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -771,14 +771,10 @@ class Map_Classifier(object):
         for data below the lowest bin. 
         """
         x = np.asarray(x).flatten()
-        uptos = [np.where(value <= self.bins)[0] for value in x]
-        #  bail upwards
-        bins = [j.min() if j.size > 0 else len(self.bins)-1 for j in uptos]
-        bins = np.asarray(bins)
-        if len(bins) == 1:
-            return bins[0]
-        else:
-            return bins
+        right = np.digitize(x, self.bins, right=True)
+        if right.max() == len(self.bins):
+            right[right == len(self.bins)] = len(self.bins)-1
+        return right
 
 
 class HeadTail_Breaks(Map_Classifier):

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -90,7 +90,7 @@ class TestMake(unittest.TestCase):
         np.testing.assert_allclose(known, ei_classes)
 
         q5r_classes = [self.q5r(d) for d in self.data]
-        known = [[0,1,2,3,4], [0,1,2,4,4], [0,0,2,4,4]]
+        known = [[0,1,2,3,4], [0,0,2,3,4], [0,0,2,4,4]]
         accreted_data = set(self.q5r.__defaults__[0].y)
         all_data = set(np.asarray(self.data).flatten())
         self.assertEqual(accreted_data, all_data)


### PR DESCRIPTION
This uses digitize in place of list comprehensions & numpy.where. 

It should be much faster for calling `find_bin` on large datasets. 

it retains a post-correction for the case where the bin index is larger than the number of bins, if any observations fall into that over-bin. 

I think it's just simpler to do a new PR than to fixup the old one. 