### PR TITLE
BUG: avoid deprecation warning in HeadTailBreaks

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -193,7 +193,7 @@ def head_tail_breaks(values, cuts):
     mean = np.mean(values)
     cuts.append(mean)
     if len(values) > 1:
-        return headTail_breaks(values[values >= mean], cuts)
+        return head_tail_breaks(values[values >= mean], cuts)
     return cuts
 
 


### PR DESCRIPTION
After recent changes of classifiers' names, HeadTailBreaks returns DeprecationWarning even if a new name if used, because it uses the old one in the function itself. That is changed to use the new name.

To reproduce call HeadTailBreaks on any data.

```
data = [1, 1, 1, 4, 5, 10]
mc.HeadTailBreaks(data)
```
```
/Users/martin/anaconda3/envs/geo_dev/lib/python3.7/site-packages/mapclassify/classifiers.py:86: DeprecationWarning: Call to deprecated function (or staticmethod) headTail_breaks. (use head_tail_breaks)
  return headTail_breaks(values[values >= mean], cuts)
```