### PR TITLE
BUG: RecursiveError in HeadTailBreaks

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -192,7 +192,7 @@ def head_tail_breaks(values, cuts):
     values = np.array(values)
     mean = np.mean(values)
     cuts.append(mean)
-    if len(values) > 1:
+    if len(set(values)) > 1:
         return head_tail_breaks(values[values >= mean], cuts)
     return cuts
 

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -330,6 +330,13 @@ class TestHeadTailBreaks(unittest.TestCase):
         self.assertEqual(len(htb.counts), 4)
         np.testing.assert_array_almost_equal(htb.counts, np.array([975, 21, 2, 1]))
 
+    def test_HeadTail_Breaks_doublemax(self):
+        V = np.append(self.V, self.V.max())
+        htb = HeadTail_Breaks(V)
+        self.assertEqual(htb.k, 4)
+        self.assertEqual(len(htb.counts), 4)
+        np.testing.assert_array_almost_equal(htb.counts, np.array([980, 17, 1, 2]))
+
 
 class TestMapClassifier(unittest.TestCase):
     def test_Map_Classifier(self):


### PR DESCRIPTION
Fixes #45 

Implemented fix suggested by @weikang9009 in #45, including test. 

In case of multiple identical maximum values, HeadTailBreak no longer raises RecursiveError but ends its search, having multiple values in the last bin (opposed to expected 1 value). 