### PR TITLE
BUG: UserDefined accepts only list if max not in bins

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -2358,7 +2358,7 @@ class UserDefined(MapClassifier):
 
     def __init__(self, y, bins):
         if bins[-1] < max(y):
-            bins.append(max(y))
+            bins = np.append(bins, max(y))
         self.k = len(bins)
         self.bins = np.array(bins)
         self.y = y

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -550,6 +550,12 @@ class TestUserDefined(unittest.TestCase):
         np.testing.assert_array_almost_equal(ud.bins, np.array([20.0, 4111.45]))
         np.testing.assert_array_almost_equal(ud.counts, np.array([37, 21]))
 
+    def test_User_Defined_max(self):
+        bins = np.array([20, 30])
+        ud = User_Defined(self.V, bins)
+        np.testing.assert_array_almost_equal(ud.bins, np.array([20.0, 30., 4111.45]))
+        np.testing.assert_array_almost_equal(ud.counts, np.array([37, 4, 17]))
+
 
 class TestMaxPClassifier(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
UserDefined attempts to add max value of given array to bins if that is not covered by given bins. However, it expects that bins are a list (`bins.append(max(y))`), while it could be any array-like. Even mapclassify's own `self.bins` gives array. I have changed this behaviour using np.append to cover all possibilities. 

Steps to replicate the issue:

```py
x = list(range(1, 1000))
y = list(range(1, 500))
nb = mc.NaturalBreaks(y)
userdefined = mc.UserDefined(x, nb.bins)
```

_(That's all from me today, I just happened to work with mapclassify a lot today and found these simple issues. Thank you for this great package!)_