### PR TITLE
[MAINT] updating supported Python versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,8 @@ def setup_package():
             'Topic :: Scientific/Engineering :: GIS',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6'
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7'
             ],
           license='3-Clause BSD',
           packages=find_packages(),


### PR DESCRIPTION
Updating the currently supported Python versions in `setup.py` from `3.5` & `3.6` to `3.6` & `3.7`, as tested in [`.travis.yml`](https://github.com/pysal/mapclassify/blob/master/.travis.yml).