### PR TITLE
Make networkx optional, remove xfail from greedy

### DIFF
--- a/mapclassify/greedy.py
+++ b/mapclassify/greedy.py
@@ -284,10 +284,15 @@ def greedy(
     color : pd.Series
         pandas.Series representing assinged color codes
     """
-    try:
-        import networkx as nx
-    except ImportError:
-        raise ImportError("The 'networkx' package is required.")
+    if strategy != "balanced":
+        try:
+            import networkx as nx
+
+            STRATEGIES = nx.algorithms.coloring.greedy_coloring.STRATEGIES.keys()
+            
+        except ImportError:
+            raise ImportError("The 'networkx' package is required.")
+
     try:
         import pandas as pd
     except ImportError:
@@ -297,9 +302,8 @@ def greedy(
     except ImportError:
         raise ImportError("The 'libpysal' package is required.")
 
-    STRATEGIES = nx.algorithms.coloring.greedy_coloring.STRATEGIES.keys()
-
     if min_distance is not None:
+        # TODO: use libpysal's fuzzy_contiguity instead of _geos_sw once pysal/libpysal#280 is released
         sw = _geos_sw(gdf, tolerance=min_distance, silence_warnings=silence_warnings)
 
     if not isinstance(sw, W):

--- a/mapclassify/tests/test_greedy.py
+++ b/mapclassify/tests/test_greedy.py
@@ -68,7 +68,7 @@ def test_random_sequential(pysal_geos):
     assert len(colors) == len(world)
     # it is based on random, does not return consistent result to be tested
 
-
+@pytest.mark.xfail(reason="temp - see where it fails")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_smallest_last(pysal_geos):
     colors = greedy(world, strategy="smallest_last", min_distance=pysal_geos)

--- a/mapclassify/tests/test_greedy.py
+++ b/mapclassify/tests/test_greedy.py
@@ -16,7 +16,6 @@ def test_default():
     assert colors.value_counts().to_list() == [36, 36, 35, 35, 35]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_count(pysal_geos):
     colors = greedy(
@@ -27,7 +26,6 @@ def test_count(pysal_geos):
     assert colors.value_counts().to_list() == [36, 36, 35, 35, 35]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_area(pysal_geos):
     colors = greedy(world, strategy="balanced", balance="area", min_distance=pysal_geos)
@@ -36,7 +34,6 @@ def test_area(pysal_geos):
     assert colors.value_counts().to_list() == [55, 49, 39, 32, 2]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_centroid(pysal_geos):
     colors = greedy(
@@ -47,7 +44,6 @@ def test_centroid(pysal_geos):
     assert colors.value_counts().to_list() == [39, 36, 36, 34, 32]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_distance(pysal_geos):
     colors = greedy(
@@ -58,7 +54,6 @@ def test_distance(pysal_geos):
     assert colors.value_counts().to_list() == [38, 36, 35, 34, 34]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_largest_first(pysal_geos):
     colors = greedy(world, strategy="largest_first", min_distance=pysal_geos)
@@ -67,7 +62,6 @@ def test_largest_first(pysal_geos):
     assert colors.value_counts().to_list() == [64, 49, 42, 21, 1]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_random_sequential(pysal_geos):
     colors = greedy(world, strategy="random_sequential", min_distance=pysal_geos)
@@ -75,7 +69,6 @@ def test_random_sequential(pysal_geos):
     # it is based on random, does not return consistent result to be tested
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_smallest_last(pysal_geos):
     colors = greedy(world, strategy="smallest_last", min_distance=pysal_geos)
@@ -84,7 +77,6 @@ def test_smallest_last(pysal_geos):
     assert colors.value_counts().to_list() == [71, 52, 39, 15]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_independent_set(pysal_geos):
     colors = greedy(world, strategy="independent_set", min_distance=pysal_geos)
@@ -93,7 +85,6 @@ def test_independent_set(pysal_geos):
     assert colors.value_counts().to_list() == [91, 42, 26, 13, 5]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_connected_sequential_bfs(pysal_geos):
     colors = greedy(world, strategy="connected_sequential_bfs", min_distance=pysal_geos)
@@ -102,7 +93,6 @@ def test_connected_sequential_bfs(pysal_geos):
     assert colors.value_counts().to_list() == [77, 46, 34, 18, 2]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_connected_sequential_dfs(pysal_geos):
     colors = greedy(world, strategy="connected_sequential_dfs", min_distance=pysal_geos)
@@ -111,7 +101,6 @@ def test_connected_sequential_dfs(pysal_geos):
     assert colors.value_counts().to_list() == [75, 52, 34, 14, 2]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_connected_sequential(pysal_geos):
     colors = greedy(world, strategy="connected_sequential", min_distance=pysal_geos)
@@ -120,7 +109,6 @@ def test_connected_sequential(pysal_geos):
     assert colors.value_counts().to_list() == [77, 46, 34, 18, 2]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_saturation_largest_first(pysal_geos):
     colors = greedy(world, strategy="saturation_largest_first", min_distance=pysal_geos)
@@ -129,7 +117,6 @@ def test_saturation_largest_first(pysal_geos):
     assert colors.value_counts().to_list() == [71, 47, 42, 17]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_DSATUR(pysal_geos):
     colors = greedy(world, strategy="DSATUR", min_distance=pysal_geos)
@@ -157,7 +144,6 @@ def test_sw():
     assert colors.value_counts().to_list() == [36, 36, 35, 35, 35]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_index(pysal_geos):
     world["ten"] = world.index * 10
@@ -168,7 +154,6 @@ def test_index(pysal_geos):
     assert colors.value_counts().to_list() == [36, 36, 35, 35, 35]
 
 
-@pytest.mark.xfail(reason="rtree missing on CI")
 def test_min_distance():
     europe = world.loc[world.continent == "Europe"].to_crs(epsg=3035)
     colors = greedy(europe, min_distance=500000)

--- a/mapclassify/tests/test_greedy.py
+++ b/mapclassify/tests/test_greedy.py
@@ -1,3 +1,5 @@
+import sys
+
 import geopandas as gpd
 from libpysal.weights import Queen
 
@@ -68,7 +70,10 @@ def test_random_sequential(pysal_geos):
     assert len(colors) == len(world)
     # it is based on random, does not return consistent result to be tested
 
-@pytest.mark.xfail(reason="temp - see where it fails")
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="networkx issue networkx/networkx#3993"
+)
 @pytest.mark.parametrize("pysal_geos", [None, 0])
 def test_smallest_last(pysal_geos):
     colors = greedy(world, strategy="smallest_last", min_distance=pysal_geos)


### PR DESCRIPTION
Small change to avoid the import of networkx in `mapclassify.greedy` if it is not used.

Since the CI now comes from conda-forge, I am also removing `@pytest.mark.xfail` (issue with rtree should be resolved).