### PR TITLE
BUG: Fix mapclassify #88

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -630,8 +630,11 @@ class MapClassifier(object):
         self.gadf = self.get_gadf()
 
     def _classify(self):
-        self._set_bins()
-        self.yb, self.counts = bin1d(self.y, self.bins)
+        if min(self.y) == max(self.y):
+            raise ValueError("Minimum and maximum of input data are equal, cannot create bins.")
+        else:
+            self._set_bins()
+            self.yb, self.counts = bin1d(self.y, self.bins)
 
     def _update(self, data, *args, **kwargs):
         """


### PR DESCRIPTION
This is a PR to fix https://github.com/pysal/mapclassify/issues/88. Changes have been made to [`_classify()` function](https://github.com/jeffcsauer/mapclassify/blob/7aad6fca0521cc29c64d43a1618dabd16a1ea965/mapclassify/classifiers.py#L632-L637) such that it now checks to see if max `y` and min `y` are equal (across multiple classifiers, not just `EqualInterval`). If max `y` and min `y` are equal there is now a `ValueError` with the following description: 

`Minimum and maximum of input data are equal, cannot create bins.`

There may be a better error message...

PR as part of the October 2020 PySAL Sprint.

@sjsrey 