### PR TITLE
CI: update conda action

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
          environment-file: [ci/36.yaml, ci/36-numba.yaml, ci/37.yaml, ci/37-numba.yaml, ci/38.yaml, ci/38-numba.yaml]
      steps:
        - uses: actions/checkout@v2
-       - uses: goanpeca/setup-miniconda@v1
+       - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
             auto-update-conda: true


### PR DESCRIPTION
Update conda recipe to avoid failure due to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/