### PR TITLE
exclude Python 3.6 for Windows

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,6 +17,11 @@
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
          environment-file: [ci/36.yaml, ci/36-numba.yaml, ci/37.yaml, ci/37-numba.yaml, ci/38.yaml, ci/38-numba.yaml]
+         exclude:
+           - environment-file: ci/36.yaml
+             os: windows-latest
+           - environment-file: ci/36-numba.yaml
+             os: windows-latest
      steps:
        - uses: actions/checkout@v2
        - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
This PR:
* excludes Python 3.6 from GHA testing on Windows.