### PR TITLE
Handle recursion error for head tails.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@
    unittests:
      name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
      runs-on: ${{ matrix.os }}
-     timeout-minutes: 25
+     timeout-minutes: 35
      strategy:
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']

--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -3,7 +3,6 @@ A module of classification schemes for choropleth mapping.
 """
 import numpy as np
 import scipy.stats as stats
-import scipy as sp
 import copy
 from sklearn.cluster import KMeans as KMEANS
 from warnings import warn as Warn
@@ -52,7 +51,7 @@ CLASSIFIERS = (
 )
 
 K = 5  # default number of classes in any map scheme with this as an argument
-SEEDRANGE = 1000000  # range for drawing random integers from for Natural Breaks
+SEEDRANGE = 1000000  # range for drawing random ints from for Natural Breaks
 
 
 FMT = "{:.2f}"
@@ -181,11 +180,7 @@ def head_tail_breaks(values, cuts):
     mean = np.mean(values)
     cuts.append(mean)
     if len(set(values)) > 1:
-        try:
-            return head_tail_breaks(values[values >= mean], cuts)
-        except RecursionError:
-            n = len(values)
-            return cuts[:n-1]
+        return head_tail_breaks(values[values > mean], cuts)
     return cuts
 
 
@@ -1144,7 +1139,6 @@ class HeadTailBreaks(MapClassifier):
         bins = head_tail_breaks(x, bins)
         self.bins = np.array(bins)
         self.k = len(self.bins)
-        
 
 class EqualInterval(MapClassifier):
     """

--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -1137,9 +1137,16 @@ class HeadTailBreaks(MapClassifier):
 
         x = self.y.copy()
         bins = []
-        bins = head_tail_breaks(x, bins)
-        self.bins = np.array(bins)
-        self.k = len(self.bins)
+        try:
+            bins = head_tail_breaks(x, bins)
+            self.bins = np.array(bins)
+            self.k = len(self.bins)
+        except RecursionError:
+            message = "Floating point issues with head-tails."
+            message += " Reverting to quantiles."
+            Warn(message, UserWarning)
+            self.bins = quantile(x, k=5)
+            self.k = len(self.bins)
 
 
 class EqualInterval(MapClassifier):

--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -181,7 +181,11 @@ def head_tail_breaks(values, cuts):
     mean = np.mean(values)
     cuts.append(mean)
     if len(set(values)) > 1:
-        return head_tail_breaks(values[values >= mean], cuts)
+        try:
+            return head_tail_breaks(values[values >= mean], cuts)
+        except RecursionError:
+            n = len(values)
+            return cuts[:n-1]
     return cuts
 
 
@@ -1137,17 +1141,10 @@ class HeadTailBreaks(MapClassifier):
 
         x = self.y.copy()
         bins = []
-        try:
-            bins = head_tail_breaks(x, bins)
-            self.bins = np.array(bins)
-            self.k = len(self.bins)
-        except RecursionError:
-            message = "Floating point issues with head-tails."
-            message += " Reverting to quantiles."
-            Warn(message, UserWarning)
-            self.bins = quantile(x, k=5)
-            self.k = len(self.bins)
-
+        bins = head_tail_breaks(x, bins)
+        self.bins = np.array(bins)
+        self.k = len(self.bins)
+        
 
 class EqualInterval(MapClassifier):
     """

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -339,6 +339,13 @@ class TestHeadTailBreaks(unittest.TestCase):
         self.assertEqual(len(htb.counts), 4)
         np.testing.assert_array_almost_equal(htb.counts, np.array([980, 17, 1, 2]))
 
+    def test_HeadTailBreaks_float(self):
+        V = np.array([1 + 2**-52, 1, 1])
+        htb = HeadTailBreaks(V)
+        self.assertEqual(htb.k, 2)
+        self.assertEqual(len(htb.counts), 2)
+        np.testing.assert_array_almost_equal(htb.counts, np.array([2, 1]))
+
 
 class TestMapClassifier(unittest.TestCase):
     def test_Map_Classifier(self):


### PR DESCRIPTION
This is addressing #92. 

```

In [10]: values = np.array([1 + 2**-52, 1, 1])

In [11]: mapclassify.HeadTailBreaks(values)
/Users/serge/Dropbox/p/pysal/src/subpackages/mapclassify/mapclassify/classifiers.py:1147:
UserWarning: Floating point issues with head-tails. Reverting to
quantiles.
  Reverting to quintiles.")
  /Users/serge/Dropbox/p/pysal/src/subpackages/mapclassify/mapclassify/classifiers.py:236:
  UserWarning: Warning: Not enough unique values in array to form k
  classes
    "Warning: Not enough unique values in array to form k classes",
    UserWarning
    /Users/serge/Dropbox/p/pysal/src/subpackages/mapclassify/mapclassify/classifiers.py:238:
    UserWarning: Warning: setting k to 2
      Warn("Warning: setting k to %d" % k_q, UserWarning)
      Out[11]:
      HeadTailBreaks

        Interval     Count
        --------------------
        [1.00, 1.00] |     2
        (1.00, 1.00] |     1

```