### PR TITLE
REGR: fix invariant array regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mapclassify/datasets/calemp/.ropeproject/
 mapclassify/tests/.ropeproject/
 setup.cfg
 .DS_Store
+.vscode/settings.json

--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -629,11 +629,8 @@ class MapClassifier(object):
         self.gadf = self.get_gadf()
 
     def _classify(self):
-        if min(self.y) == max(self.y):
-            raise ValueError("Minimum and maximum of input data are equal, cannot create bins.")
-        else:
-            self._set_bins()
-            self.yb, self.counts = bin1d(self.y, self.bins)
+        self._set_bins()
+        self.yb, self.counts = bin1d(self.y, self.bins)
 
     def _update(self, data, *args, **kwargs):
         """
@@ -1193,7 +1190,8 @@ class EqualInterval(MapClassifier):
         see class docstring
 
         """
-
+        if min(y) == max(y):
+            raise ValueError("Not enough unique values in array to form k classes.")
         self.k = k
         MapClassifier.__init__(self, y)
         self.name = "EqualInterval"
@@ -1591,6 +1589,8 @@ class MaximumBreaks(MapClassifier):
     """
 
     def __init__(self, y, k=5, mindiff=0):
+        if min(y) == max(y):
+            raise ValueError("Not enough unique values in array to form k classes.")
         self.k = k
         self.mindiff = mindiff
         MapClassifier.__init__(self, y)
@@ -2109,6 +2109,8 @@ class JenksCaspallForced(MapClassifier):
     """
 
     def __init__(self, y, k=K):
+        if min(y) == max(y):
+            raise ValueError("Not enough unique values in array to form k classes.")
         self.k = k
         MapClassifier.__init__(self, y)
         self.name = "JenksCaspallForced"
@@ -2390,6 +2392,8 @@ class MaxP(MapClassifier):
     """
 
     def __init__(self, y, k=K, initial=1000):
+        if min(y) == max(y):
+            raise ValueError("Not enough unique values in array to form k classes.")
         self.k = k
         self.initial = initial
         MapClassifier.__init__(self, y)

--- a/mapclassify/tests/test_mapclassify.py
+++ b/mapclassify/tests/test_mapclassify.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
 import types
+import pytest
 from ..classifiers import *
 from ..classifiers import binC, bin, bin1d, load_example
 from ..pooling import Pooled
@@ -340,7 +341,7 @@ class TestHeadTailBreaks(unittest.TestCase):
         np.testing.assert_array_almost_equal(htb.counts, np.array([980, 17, 1, 2]))
 
     def test_HeadTailBreaks_float(self):
-        V = np.array([1 + 2**-52, 1, 1])
+        V = np.array([1 + 2 ** -52, 1, 1])
         htb = HeadTailBreaks(V)
         self.assertEqual(htb.k, 2)
         self.assertEqual(len(htb.counts), 2)
@@ -388,6 +389,11 @@ class TestEqualInterval(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             ei.bins, np.array([822.394, 1644.658, 2466.922, 3289.186, 4111.45])
         )
+
+        with pytest.raises(
+            ValueError, match="Not enough unique values in array to form k classes."
+        ):
+            EqualInterval(np.array([1, 1, 1, 1]))
 
 
 class TestPercentiles(unittest.TestCase):
@@ -479,6 +485,11 @@ class TestMaximumBreaks(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(mb.counts, np.array([50, 2, 4, 1, 1]))
 
+        with pytest.raises(
+            ValueError, match="Not enough unique values in array to form k classes."
+        ):
+            MaximumBreaks(np.array([1, 1, 1, 1]))
+
 
 class TestFisherJenks(unittest.TestCase):
     def setUp(self):
@@ -555,6 +566,11 @@ class TestJenksCaspallForced(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(jcf.counts, np.array([12, 12, 13, 9, 12]))
 
+        with pytest.raises(
+            ValueError, match="Not enough unique values in array to form k classes."
+        ):
+            JenksCaspallForced(np.array([1, 1, 1, 1]))
+
 
 class TestUserDefined(unittest.TestCase):
     def setUp(self):
@@ -593,6 +609,11 @@ class TestMaxP(unittest.TestCase):
             ),
         )
         np.testing.assert_array_almost_equal(mp.counts, np.array([29, 8, 1, 10, 10]))
+
+        with pytest.raises(
+            ValueError, match="Not enough unique values in array to form k classes."
+        ):
+            MaxP(np.array([1, 1, 1, 1]))
 
 
 class TestGadf(unittest.TestCase):


### PR DESCRIPTION
Resolves #100 

I have moved the check for invariant array (all values are the same) into individual classifiers which are affected by that. The rest either have their own meaningful error messages for this situation or are able to handle it.

@sjsrey can we merge this and #99 and make a quick bugfix release 2.4.1 before PySAL meta?