### PR TITLE
Enable python 2 install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 import os
 import sys
+from io import open
 from os.path import relpath, join as pjoin
 from distutils.command.build_py import build_py
 


### PR DESCRIPTION
This works with 2 and 3, so seems harmless to add an enable both