### PR TITLE
remove numba cache from fisher jenks

### DIFF
--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -67,7 +67,7 @@ try:
 except ImportError:
     HAS_NUMBA = False
 
-    def njit(_type, cache):  # noqa ARG001
+    def njit(_type):  # noqa ARG001
         def decorator_njit(func):
             @functools.wraps(func)
             def wrapper_decorator(*args, **kwargs):

--- a/mapclassify/classifiers.py
+++ b/mapclassify/classifiers.py
@@ -580,7 +580,7 @@ def natural_breaks(values, k=5, init=10):
     return (sids, class_ids, fit, cuts)
 
 
-@njit("f8[:](f8[:], u2)", cache=True)
+@njit("f8[:](f8[:], u2)")
 def _fisher_jenks_means(values, classes=5):
     """
     Jenks Optimal (Natural Breaks) algorithm implemented in Python.


### PR DESCRIPTION
Numba is writing cache to tmp file in` __pycache__` in the environment's site packages. If you install your conda env with admin rights and then try to run mapclassify with user rights, this will fail, as @jorisvandenbossche noticed while teaching. 

The cache is there to cache JIT-ted version of the function so it does not have to be compiled in a new Python runtime again. There's a lot of gotcha's in the [docs](https://numba.readthedocs.io/en/stable/user/jit.html#cache) for caching, plus the one above. I suppose that the benefit of caching is in the end smaller than the issues it may cause, so I am suggesting removing `cache=True`.