### PR TITLE
Require arrays to be equal…, & xfail equality of instances of stochastic classes

### DIFF
--- a/mapclassify/tests/test_classify.py
+++ b/mapclassify/tests/test_classify.py
@@ -7,9 +7,9 @@ import mapclassify
 
 def _assertions(a, b):
     assert a.k == b.k
-    assert a.yb.all() == b.yb.all()
-    assert a.bins.all() == b.bins.all()
-    assert a.counts.all() == b.counts.all()
+    assert (a.yb == b.yb).all()
+    assert (a.bins == b.bins).all()
+    assert (a.counts == b.counts).all()
 
 
 class TestClassify:
@@ -33,6 +33,10 @@ class TestClassify:
         b = mapclassify.FisherJenks(self.x, k=3)
         _assertions(a, b)
 
+    # mapclassify\classifiers.py:FisherJenksSampled.__init__
+    # 2028  ids = np.random.randint(0, n, int(n * pct)) 
+    @pytest.mark.xfail(reason="Stochastic. Passing a.s. requires random samples "
+                              "to be the same in both instances. ")
     def test_fisher_jenks_sampled(self):
         a = mapclassify.classify(
             self.x, "FisherJenksSampled", k=3, pct_sampled=0.5, truncate=False
@@ -69,16 +73,29 @@ class TestClassify:
         b = mapclassify.JenksCaspallForced(self.x, k=3)
         _assertions(a, b)
 
+
+    # mapclassify\classifiers.py:JenksCaspallSampled.__init__
+    # 2224  ids = np.random.randint(0, n, int(n * pct)) 
+    @pytest.mark.xfail(reason="Stochastic. Passing a.s. requires random samples "
+                              "to be the same in both instances. ")
     def test_jenks_caspall_sampled(self):
         a = mapclassify.classify(self.x, "JenksCaspallSampled", pct_sampled=0.5)
         b = mapclassify.JenksCaspallSampled(self.x, pct=0.5)
         _assertions(a, b)
 
+    # KMeans iterates starting from a randomly generated centroids
+    @pytest.mark.xfail(reason="Stochastic. Passing a.s. requires random centroids "
+                              "to be the same in both instances. ")
     def test_natural_breaks(self):
         a = mapclassify.classify(self.x, "natural_breaks")
         b = mapclassify.NaturalBreaks(self.x)
         _assertions(a, b)
 
+    # mapclassify\classifiers.py:MaxP._set_bins
+    # 2656  rseeds = np.random.permutation(list(range(k))).tolist()
+    # 2701  rseeds = np.random.permutation(list(range(k))).tolist()
+    @pytest.mark.xfail(reason="Stochastic. Passing a.s. requires random selections "
+                              "to be the same in both instances. ")
     def test_max_p_classifier(self):
         a = mapclassify.classify(self.x, "max_p", k=3, initial=50)
         b = mapclassify.MaxP(self.x, k=3, initial=50)


### PR DESCRIPTION
not just either both all truthy or both not.  

Fixes issue #202.

All the tests apart from the stochastic ones I've xfailed still pass - they were not testing much useful other than the correct
selection of MapClassifier sub classes by the factory function and assignemnt of args, but still:

Well done guys!  This set of tests is much stricter, and they're all still passed.  Arrays of random numbers should not be tested using equality, so I've just xfailed those tests until someone has a better suggestion.