### PR TITLE
Fix typo: visualizaiton -> visualization

### DIFF
--- a/notebooks/03_choropleth.ipynb
+++ b/notebooks/03_choropleth.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Choropleth\n",
     "\n",
-    "`mapclassify` is intended to be used with visualizaiton packages to handle the actual rendering of the choropleth maps defined on its classifiers. In this notebook, we explore some examples of how this is done. The notebook also includes an example that combines `mapclassify` with [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/) to allow for the interactive exploration of the choice of:\n",
+    "`mapclassify` is intended to be used with visualization packages to handle the actual rendering of the choropleth maps defined on its classifiers. In this notebook, we explore some examples of how this is done. The notebook also includes an example that combines `mapclassify` with [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/) to allow for the interactive exploration of the choice of:\n",
     "\n",
     "- classification method\n",
     "- number of classes\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 license = {text = "BSD 3-Clause"}
 description = "Classification Schemes for Choropleth Maps."
-keywords = ["spatial statistics", "geovisualizaiton"]
+keywords = ["spatial statistics", "geovisualization"]
 readme = {text = """\
 `mapclassify` implements a family of classification schemes for choropleth maps.
 Its focus is on the determination of the number of classes, and the assignment


### PR DESCRIPTION
Fixed a typo in the keywords in the pyproject.toml file and in a notebook.