### PR TITLE
CI: ensure 3.9 envs are compatible

### DIFF
--- a/ci/39-min.yaml
+++ b/ci/39-min.yaml
@@ -10,7 +10,7 @@ dependencies:
   - scikit-learn=1.0
   - scipy=1.8
   # testing
-  - geopandas
+  - geopandas=0.13
   - libpysal
   - pytest
   - pytest-cov

--- a/ci/39-min.yaml
+++ b/ci/39-min.yaml
@@ -10,7 +10,7 @@ dependencies:
   - scikit-learn=1.0
   - scipy=1.8
   # testing
-  - geopandas=0.13
+  - geopandas<1
   - libpysal
   - pytest
   - pytest-cov

--- a/ci/39-numba.yaml
+++ b/ci/39-numba.yaml
@@ -10,8 +10,8 @@ dependencies:
   - scikit-learn
   - scipy
   # testing
-  - geopandas
-  - libpysal>=4.9
+  - geopandas<1
+  - libpysal
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/ci/39-numba.yaml
+++ b/ci/39-numba.yaml
@@ -11,7 +11,7 @@ dependencies:
   - scipy
   # testing
   - geopandas
-  - libpysal
+  - libpysal>=4.9
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -10,8 +10,8 @@ dependencies:
   - scikit-learn
   - scipy
   # testing
-  - geopandas
-  - libpysal>=4.9
+  - geopandas<1
+  - libpysal
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -11,7 +11,7 @@ dependencies:
   - scipy
   # testing
   - geopandas
-  - libpysal
+  - libpysal>=4.9
   - pytest
   - pytest-cov
   - pytest-xdist


### PR DESCRIPTION
libpysal 4.9.0 which contains compatibility fixes with GeoPandas 1.0 requires python 3.9, hence our red CI. Pinning.