### PR TITLE
CI: doctest only on ubuntu latest

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,7 +63,17 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest mapclassify -r a -v -n auto --doctest-modules --cov mapclassify --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
+          pytest mapclassify -r a -v -n auto --cov mapclassify --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
+
+      - name: run docstring tests
+        if: contains(matrix.environment-file, '311-numba') && contains(matrix.os, 'ubuntu')
+        run: |
+          pytest \
+          -v \
+          -r a \
+          -n auto \
+          --color yes \
+          --doctest-only mapclassify
 
       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
         uses: codecov/codecov-action@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest mapclassify -r a -v -n auto --cov mapclassify --cov-config .coveragerc --cov-report xml --color yes --cov-append --cov-report term-missing
+          pytest mapclassify -r a -v -n auto --cov mapclassify --cov-report xml --color yes --cov-append --cov-report term-missing
 
       - name: run docstring tests
         if: contains(matrix.environment-file, '311-numba') && contains(matrix.os, 'ubuntu')
@@ -73,7 +73,7 @@ jobs:
           -r a \
           -n auto \
           --color yes \
-          --cov mapclassify --cov-config .coveragerc --cov-report xml --cov-append \
+          --cov mapclassify --cov-report xml --cov-append \
           --doctest-only mapclassify
 
       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,6 +73,7 @@ jobs:
           -r a \
           -n auto \
           --color yes \
+          --cov mapclassify --cov-config .coveragerc --cov-report xml --cov-append \
           --doctest-only mapclassify
 
       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})

--- a/ci/311-numba.yaml
+++ b/ci/311-numba.yaml
@@ -15,6 +15,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pytest-doctestplus
   - codecov
   - matplotlib
   # optional


### PR DESCRIPTION
Following the spaghetti model but being a bit more restrictive on when it runs.