### PR TITLE
CI: test against Python 3.12

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,16 +29,18 @@ jobs:
             ci/310-numba.yaml,
             ci/311.yaml,
             ci/311-numba.yaml,
-            ci/311-dev.yaml,
+            ci/312.yaml,
+            ci/312-numba.yaml,
+            ci/312-dev.yaml,
           ]
         include:
-          - environment-file: ci/311.yaml
+          - environment-file: ci/312.yaml
             os: macos-latest
-          - environment-file: ci/311-numba.yaml
+          - environment-file: ci/312-numba.yaml
             os: macos-latest
-          - environment-file: ci/311.yaml
+          - environment-file: ci/312.yaml
             os: windows-latest
-          - environment-file: ci/311-numba.yaml
+          - environment-file: ci/312-numba.yaml
             os: windows-latest
       fail-fast: false
 
@@ -66,7 +68,7 @@ jobs:
           pytest mapclassify -r a -v -n auto --cov mapclassify --cov-report xml --color yes --cov-append --cov-report term-missing
 
       - name: run docstring tests
-        if: contains(matrix.environment-file, '311-numba') && contains(matrix.os, 'ubuntu')
+        if: contains(matrix.environment-file, '312-numba') && contains(matrix.os, 'ubuntu')
         run: |
           pytest \
           -v \

--- a/ci/311-numba.yaml
+++ b/ci/311-numba.yaml
@@ -15,7 +15,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - pytest-doctestplus
   - codecov
   - matplotlib
   # optional

--- a/ci/312-dev.yaml
+++ b/ci/312-dev.yaml
@@ -2,7 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.12
   # testing
   - pytest
   - pytest-cov

--- a/ci/312-numba.yaml
+++ b/ci/312-numba.yaml
@@ -1,0 +1,22 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  # required
+  - networkx
+  - numpy
+  - pandas
+  - scikit-learn
+  - scipy
+  # testing
+  - geopandas
+  - libpysal
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - pytest-doctestplus
+  - codecov
+  - matplotlib
+  # optional
+  - numba

--- a/ci/312.yaml
+++ b/ci/312.yaml
@@ -1,0 +1,26 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  # required
+  - networkx
+  - numpy
+  - pandas
+  - scikit-learn
+  - scipy
+  # testing
+  - geopandas
+  - libpysal
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - codecov
+  - matplotlib
+  # docs
+  - nbsphinx
+  - numpydoc
+  - sphinx
+  - sphinx-gallery
+  - sphinxcontrib-bibtex
+  - sphinx_bootstrap_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ tests = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "pytest-doctestplus",
 ]
 all = ["numba[speedups,dev,docs,tests]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
@@ -94,7 +95,6 @@ extend-exclude = '''
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
-target-version = "py39"
 ignore = [
     "B006",
     "B008",


### PR DESCRIPTION
Include testing against 3.12. Given mapclassify is quite crucial dependency of geopandas, which still support 3.9, I'd keep it for a bit longer than usual.