### PR TITLE
reimplement rgbas

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,3 +41,4 @@ Utilities
     mapclassify.Pooled
     mapclassify.classify
     mapclassify.gadf
+    mapclassify.util.get_color_array

--- a/mapclassify/tests/test_rgba.py
+++ b/mapclassify/tests/test_rgba.py
@@ -1,7 +1,7 @@
 import geopandas
 import numpy as np
 from numpy.testing import assert_array_equal
-from mapclassify.util import get_rgba
+from mapclassify.util import get_color_array
 
 world = geopandas.read_file(
     "https://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries.zip"
@@ -9,6 +9,11 @@ world = geopandas.read_file(
 
 
 def test_rgba():
-    colors = get_rgba(world.area, cmap="viridis")[0]
+    colors = get_color_array(world.area, cmap="viridis")[0]
     assert_array_equal(colors, np.array([68, 1, 84, 255])) 
+    
+
+def test_rgba():
+    colors = get_color_array(world.area, cmap="viridis", as_hex=True)[0]
+    assert_array_equal(colors,'#440154') 
     

--- a/mapclassify/tests/test_rgba.py
+++ b/mapclassify/tests/test_rgba.py
@@ -1,5 +1,6 @@
 import geopandas
 import numpy as np
+from numpy.testing import assert_array_equal
 from mapclassify.util import get_rgba
 
 world = geopandas.read_file(
@@ -9,9 +10,5 @@ world = geopandas.read_file(
 
 def test_rgba():
     colors = get_rgba(world.area, cmap="viridis")[0]
-    assert colors == [
-        np.float64(68.08602),
-        np.float64(1.24287),
-        np.float64(84.000825),
-        np.float64(255.0),
-    ]
+    assert_array_equal(colors, np.array([68, 1, 84, 255])) 
+    

--- a/mapclassify/util.py
+++ b/mapclassify/util.py
@@ -43,13 +43,6 @@ def get_color_array(
         each row. If `as_hex` is True, the array is :math:`(n,1)` holding a hexcolor in
         each row.
 
-    Examples
-    ---------
-
-
-
-
-
     """
     try:
         import pandas as pd

--- a/mapclassify/util.py
+++ b/mapclassify/util.py
@@ -17,7 +17,7 @@ def get_rgba(
     ----------
     values : list-like
         array of input values
-    classifier : str, optional
+    scheme : str, optional
         string description of a mapclassify classifier, by default "quantiles"
     cmap : str, optional
         name of matplotlib colormap to use, by default "viridis"

--- a/mapclassify/util.py
+++ b/mapclassify/util.py
@@ -44,8 +44,6 @@ def get_rgba(
         raise ValueError("alpha must be in the range [0,1]")
     if not pd.api.types.is_list_like(nan_color) and not len(nan_color) == 4:
         raise ValueError("`nan_color` must be list-like of 4 values: (R,G,B,A)")
-    if scheme in kwargs:
-        kwargs.pop("scheme")
 
     # only operate on non-NaN values
     v = pd.Series(values, dtype=object)

--- a/mapclassify/util.py
+++ b/mapclassify/util.py
@@ -18,7 +18,7 @@ def get_rgba(
     values : list-like
         array of input values
     scheme : str, optional
-        string description of a mapclassify classifier, by default "quantiles"
+        string description of a mapclassify classifier, by default `"quantiles"`
     cmap : str, optional
         name of matplotlib colormap to use, by default "viridis"
     alpha : float
@@ -31,7 +31,7 @@ def get_rgba(
     Returns
     -------
     numpy.array
-        numpy array (n,4) of lists with each list containing four values that define a
+        numpy array :math:`(n,4)` with each row containing four values that define a
         color using RGBA specification.
     """
     try:

--- a/mapclassify/util.py
+++ b/mapclassify/util.py
@@ -67,7 +67,7 @@ def get_color_array(
     normalized_vals = norm(bins)
 
     # generate RBGA array and convert to series
-    rgbas = colormaps[cmap](normalized_vals, bytes=True)
+    rgbas = colormaps[cmap](normalized_vals, bytes=True, alpha=alpha)
     colors = pd.Series(list(rgbas), index=legit_indices).apply(np.array)
 
     # put colors in their correct places and fill empty with designated color


### PR DESCRIPTION
- fixes a bug when the 'scheme' argument is passed
- reimplement using matplotlib's vectorized method; much faster
- give back numpy instead of lists