### PR TITLE
pin max fiona in oldest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: 'mapclassify\/'
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.1"
+    rev: "v0.6.5"
     hooks:
       - id: ruff
       - id: ruff-format

--- a/ci/310-oldest.yaml
+++ b/ci/310-oldest.yaml
@@ -10,6 +10,7 @@ dependencies:
   - scikit-learn=1.0
   - scipy=1.8
   # testing
+  - fiona<1.10
   - geopandas<1
   - libpysal
   - pytest

--- a/ci/39-oldest.yaml
+++ b/ci/39-oldest.yaml
@@ -10,6 +10,7 @@ dependencies:
   - scikit-learn=1.0
   - scipy=1.8
   # testing
+  - fiona<1.10
   - geopandas<1
   - libpysal
   - pytest


### PR DESCRIPTION
This MR:
* pins `Fiona<1.10` in `py3{9,10}-oldest` CI
* update ruff version in pre-commit
* xref https://github.com/pysal/pysal/issues/1356